### PR TITLE
Add my package replaced intent functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.4
+
+* Add `autoRunOnMyPackageReplaced` field to `ForegroundTaskOptions`. Check the readme for more details.
+
 ## 6.1.3
 
 * [**DOCS**] Update readme [#192](https://github.com/Dev-hwang/flutter_foreground_task/issues/192)

--- a/README.md
+++ b/README.md
@@ -731,13 +731,14 @@ Notification options for iOS platform.
 
 Data class with foreground task options.
 
-| Property        | Description                                                                             |
-|-----------------|-----------------------------------------------------------------------------------------|
-| `interval`      | The task call interval in milliseconds. The default is `5000`.                          |
-| `isOnceEvent`   | Whether to invoke the onRepeatEvent of `TaskHandler` only once. The default is `false`. |
-| `autoRunOnBoot` | Whether to automatically run foreground task on boot. The default is `false`.           |
-| `allowWakeLock` | Whether to keep the CPU turned on. The default is `true`.                               |
-| `allowWifiLock` | Allows an application to keep the Wi-Fi radio awake. The default is `false`.            |
+| Property                     | Description                                                                                                  |
+|------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `interval`                   | The task call interval in milliseconds. The default is `5000`.                                               |
+| `isOnceEvent`                | Whether to invoke the onRepeatEvent of `TaskHandler` only once. The default is `false`.                      |
+| `autoRunOnBoot`              | Whether to automatically run foreground task on boot. The default is `false`.                                |
+| `autoRunOnMyPackageReplaced` | Whether to automatically run foreground task on my package replaced intent received. The default is `false`. |
+| `allowWakeLock`              | Whether to keep the CPU turned on. The default is `true`.                                                    |
+| `allowWifiLock`              | Allows an application to keep the Wi-Fi radio awake. The default is `false`.                                 |
 
 ### :chicken: NotificationChannelImportance
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,11 +8,12 @@
 
     <application>
         <receiver
-            android:name=".service.BootReceiver"
+            android:name=".service.IntentReceiver"
             android:enabled="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
             </intent-filter>
         </receiver>
         <receiver

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/PreferencesKey.kt
@@ -35,6 +35,7 @@ object PreferencesKey {
     const val TASK_INTERVAL = "interval"
     const val IS_ONCE_EVENT = "isOnceEvent"
     const val AUTO_RUN_ON_BOOT = "autoRunOnBoot"
+    const val AUTO_RUN_ON_MY_PACKAGE_REPLACED = "autoRunOnMyPackageReplaced"
     const val ALLOW_WAKE_LOCK = "allowWakeLock"
     const val ALLOW_WIFI_LOCK = "allowWifiLock"
     const val CALLBACK_HANDLE = "callbackHandle"

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskOptions.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/models/ForegroundTaskOptions.kt
@@ -7,6 +7,7 @@ data class ForegroundTaskOptions(
     val interval: Long,
     val isOnceEvent: Boolean,
     val autoRunOnBoot: Boolean,
+    val autoRunOnMyPackageReplaced: Boolean,
     val allowWakeLock: Boolean,
     val allowWifiLock: Boolean,
     val callbackHandle: Long?
@@ -19,6 +20,7 @@ data class ForegroundTaskOptions(
             val interval = prefs.getLong(PrefsKey.TASK_INTERVAL, 5000L)
             val isOnceEvent = prefs.getBoolean(PrefsKey.IS_ONCE_EVENT, false)
             val autoRunOnBoot = prefs.getBoolean(PrefsKey.AUTO_RUN_ON_BOOT, false)
+            val autoRunOnMyPackageReplaced = prefs.getBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, false)
             val allowWakeLock = prefs.getBoolean(PrefsKey.ALLOW_WAKE_LOCK, true)
             val allowWifiLock = prefs.getBoolean(PrefsKey.ALLOW_WIFI_LOCK, false)
             val callbackHandle = if (prefs.contains(PrefsKey.CALLBACK_HANDLE)) {
@@ -31,6 +33,7 @@ data class ForegroundTaskOptions(
                 interval = interval,
                 isOnceEvent = isOnceEvent,
                 autoRunOnBoot = autoRunOnBoot,
+                autoRunOnMyPackageReplaced = autoRunOnMyPackageReplaced,
                 allowWakeLock = allowWakeLock,
                 allowWifiLock = allowWifiLock,
                 callbackHandle = callbackHandle
@@ -44,6 +47,7 @@ data class ForegroundTaskOptions(
             val interval = "${map?.get(PrefsKey.TASK_INTERVAL)}".toLongOrNull() ?: 5000L
             val isOnceEvent = map?.get(PrefsKey.IS_ONCE_EVENT) as? Boolean ?: false
             val autoRunOnBoot = map?.get(PrefsKey.AUTO_RUN_ON_BOOT) as? Boolean ?: false
+            val autoRunOnMyPackageReplaced = map?.get(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED) as? Boolean ?: false
             val allowWakeLock = map?.get(PrefsKey.ALLOW_WAKE_LOCK) as? Boolean ?: true
             val allowWifiLock = map?.get(PrefsKey.ALLOW_WIFI_LOCK) as? Boolean ?: false
             val callbackHandle = "${map?.get(PrefsKey.CALLBACK_HANDLE)}".toLongOrNull()
@@ -52,6 +56,7 @@ data class ForegroundTaskOptions(
                 putLong(PrefsKey.TASK_INTERVAL, interval)
                 putBoolean(PrefsKey.IS_ONCE_EVENT, isOnceEvent)
                 putBoolean(PrefsKey.AUTO_RUN_ON_BOOT, autoRunOnBoot)
+                putBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, autoRunOnMyPackageReplaced)
                 putBoolean(PrefsKey.ALLOW_WAKE_LOCK, allowWakeLock)
                 putBoolean(PrefsKey.ALLOW_WIFI_LOCK, allowWifiLock)
                 remove(PrefsKey.CALLBACK_HANDLE)
@@ -67,6 +72,7 @@ data class ForegroundTaskOptions(
             val interval = "${map?.get(PrefsKey.TASK_INTERVAL)}".toLongOrNull()
             val isOnceEvent = map?.get(PrefsKey.IS_ONCE_EVENT) as? Boolean
             val autoRunOnBoot = map?.get(PrefsKey.AUTO_RUN_ON_BOOT) as? Boolean
+            val autoRunOnMyPackageReplaced = map?.get(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED) as? Boolean ?: false
             val allowWakeLock = map?.get(PrefsKey.ALLOW_WAKE_LOCK) as? Boolean
             val allowWifiLock = map?.get(PrefsKey.ALLOW_WIFI_LOCK) as? Boolean
             val callbackHandle = "${map?.get(PrefsKey.CALLBACK_HANDLE)}".toLongOrNull()
@@ -75,6 +81,7 @@ data class ForegroundTaskOptions(
                 interval?.let { putLong(PrefsKey.TASK_INTERVAL, it) }
                 isOnceEvent?.let { putBoolean(PrefsKey.IS_ONCE_EVENT, it) }
                 autoRunOnBoot?.let { putBoolean(PrefsKey.AUTO_RUN_ON_BOOT, it) }
+                autoRunOnMyPackageReplaced?.let { putBoolean(PrefsKey.AUTO_RUN_ON_MY_PACKAGE_REPLACED, it) }
                 allowWakeLock?.let { putBoolean(PrefsKey.ALLOW_WAKE_LOCK, it) }
                 allowWifiLock?.let { putBoolean(PrefsKey.ALLOW_WIFI_LOCK, it) }
                 callbackHandle?.let { putLong(PrefsKey.CALLBACK_HANDLE, it) }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
@@ -14,14 +14,19 @@ import com.pravera.flutter_foreground_task.models.ForegroundTaskOptions
  * @author Dev-hwang
  * @version 1.0
  */
-class BootReceiver : BroadcastReceiver() {
+class IntentReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (context != null && intent?.action == "android.intent.action.BOOT_COMPLETED") {
-            // Check whether to start the service at boot time.
+        if (context != null && (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED)) {
+
             val options = ForegroundTaskOptions.getData(context)
+
+            // Check whether to start the service at boot time.
             if (!options.autoRunOnBoot) return
 
-            // Create an intent for calling the service and store the action to be executed.
+            //Check whether to start the service on my package replaced time.
+            if (!options.autoRunOnMyPackageReplaced) return
+
+            // Create an intent for calling the service and store the action to be executed
             val nIntent = Intent(context, ForegroundService::class.java)
             ForegroundServiceStatus.putData(context, ForegroundServiceAction.REBOOT)
             ContextCompat.startForegroundService(context, nIntent)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
@@ -16,16 +16,17 @@ import com.pravera.flutter_foreground_task.models.ForegroundTaskOptions
  */
 class IntentReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
+        if(context == null) return
         val options = ForegroundTaskOptions.getData(context)
 
-        if(context == null) return
+
         // Check whether to start the service at boot time.
         if(intent?.action == Intent.ACTION_BOOT_COMPLETED && !options.autoRunOnBoot) return
         //Check whether to start the service on my package replaced time.
         if(intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED && !options.autoRunOnMyPackageReplaced) return
 
 
-        if(context != null && (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED)) {
+        if(intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
             // Create an intent for calling the service and store the action to be executed
             val nIntent = Intent(context, ForegroundService::class.java)
             ForegroundServiceStatus.putData(context, ForegroundServiceAction.REBOOT)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
@@ -25,7 +25,7 @@ class IntentReceiver : BroadcastReceiver() {
         if(intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED && !options.autoRunOnMyPackageReplaced) return
 
 
-        if(intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED)) {
+        if(context != null && (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED)) {
             // Create an intent for calling the service and store the action to be executed
             val nIntent = Intent(context, ForegroundService::class.java)
             ForegroundServiceStatus.putData(context, ForegroundServiceAction.REBOOT)

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
@@ -9,7 +9,7 @@ import com.pravera.flutter_foreground_task.models.ForegroundServiceStatus
 import com.pravera.flutter_foreground_task.models.ForegroundTaskOptions
 
 /**
- * The receiver that receives the BOOT_COMPLETED and MY_PACKAGE_REPLACED event.
+ * The receiver that receives the BOOT_COMPLETED and MY_PACKAGE_REPLACED intent.
  *
  * @author Dev-hwang
  * @version 1.0
@@ -17,20 +17,24 @@ import com.pravera.flutter_foreground_task.models.ForegroundTaskOptions
 class IntentReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         if(context == null) return
+
         val options = ForegroundTaskOptions.getData(context)
 
-
-        // Check whether to start the service at boot time.
-        if(intent?.action == Intent.ACTION_BOOT_COMPLETED && !options.autoRunOnBoot) return
-        //Check whether to start the service on my package replaced time.
-        if(intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED && !options.autoRunOnMyPackageReplaced) return
-
-
-        if(intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED) {
-            // Create an intent for calling the service and store the action to be executed
-            val nIntent = Intent(context, ForegroundService::class.java)
-            ForegroundServiceStatus.putData(context, ForegroundServiceAction.REBOOT)
-            ContextCompat.startForegroundService(context, nIntent)
+        // Check whether to start the service at boot intent.
+        if(intent?.action == Intent.ACTION_BOOT_COMPLETED && options.autoRunOnBoot) {
+            return startForegroundService(context)
         }
+
+        //Check whether to start the service on my package replaced intent.
+        if(intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED && options.autoRunOnMyPackageReplaced) {
+            return startForegroundService(context)
+        }
+    }
+
+    private fun startForegroundService(context: Context) {
+        // Create an intent for calling the service and store the action to be executed
+        val nIntent = Intent(context, ForegroundService::class.java)
+        ForegroundServiceStatus.putData(context, ForegroundServiceAction.REBOOT)
+        ContextCompat.startForegroundService(context, nIntent)
     }
 }

--- a/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
+++ b/android/src/main/kotlin/com/pravera/flutter_foreground_task/service/IntentReceiver.kt
@@ -9,23 +9,23 @@ import com.pravera.flutter_foreground_task.models.ForegroundServiceStatus
 import com.pravera.flutter_foreground_task.models.ForegroundTaskOptions
 
 /**
- * The receiver that receives the BOOT_COMPLETED event.
+ * The receiver that receives the BOOT_COMPLETED and MY_PACKAGE_REPLACED event.
  *
  * @author Dev-hwang
  * @version 1.0
  */
 class IntentReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        if (context != null && (intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED)) {
+        val options = ForegroundTaskOptions.getData(context)
 
-            val options = ForegroundTaskOptions.getData(context)
+        if(context == null) return
+        // Check whether to start the service at boot time.
+        if(intent?.action == Intent.ACTION_BOOT_COMPLETED && !options.autoRunOnBoot) return
+        //Check whether to start the service on my package replaced time.
+        if(intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED && !options.autoRunOnMyPackageReplaced) return
 
-            // Check whether to start the service at boot time.
-            if (!options.autoRunOnBoot) return
 
-            //Check whether to start the service on my package replaced time.
-            if (!options.autoRunOnMyPackageReplaced) return
-
+        if(intent?.action == Intent.ACTION_BOOT_COMPLETED || intent?.action == Intent.ACTION_MY_PACKAGE_REPLACED)) {
             // Create an intent for calling the service and store the action to be executed
             val nIntent = Intent(context, ForegroundService::class.java)
             ForegroundServiceStatus.putData(context, ForegroundServiceAction.REBOOT)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -164,6 +164,7 @@ class _ExamplePageState extends State<ExamplePage> {
         interval: 5000,
         isOnceEvent: false,
         autoRunOnBoot: true,
+        autoRunOnMyPackageReplaced: true,
         allowWakeLock: true,
         allowWifiLock: true,
       ),

--- a/lib/models/foreground_task_options.dart
+++ b/lib/models/foreground_task_options.dart
@@ -5,6 +5,7 @@ class ForegroundTaskOptions {
     this.interval = 5000,
     this.isOnceEvent = false,
     this.autoRunOnBoot = false,
+    this.autoRunOnMyPackageReplaced = false,
     this.allowWakeLock = true,
     this.allowWifiLock = false,
   }) : assert(interval > 0);
@@ -20,6 +21,10 @@ class ForegroundTaskOptions {
   /// Whether to automatically run foreground task on boot.
   /// The default is `false`.
   final bool autoRunOnBoot;
+
+  /// Whether to automatically run foreground task when the my package replaced intent is received.
+  // The default is `false`.
+  final bool autoRunOnMyPackageReplaced;
 
   /// Whether to keep the CPU turned on.
   /// The default is `true`.
@@ -37,6 +42,7 @@ class ForegroundTaskOptions {
       'interval': interval,
       'isOnceEvent': isOnceEvent,
       'autoRunOnBoot': autoRunOnBoot,
+      'autoRunOnMyPackageReplaced': autoRunOnMyPackageReplaced,
       'allowWakeLock': allowWakeLock,
       'allowWifiLock': allowWifiLock,
     };


### PR DESCRIPTION
## What

This PR will add the functionality to give the package an option to restart the foregroudn service when the MY_PACKAGE_REPLACED intent has been triggered.

## Why

Explain why these things are changes. This explanation is for your colleagues and your future self.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
